### PR TITLE
🧪 Add unit tests for OmniDateParserConfig.defaults()

### DIFF
--- a/src/test/java/io/github/snekse/jdk/dateparser/OmniDateParserConfigTest.java
+++ b/src/test/java/io/github/snekse/jdk/dateparser/OmniDateParserConfigTest.java
@@ -1,0 +1,34 @@
+package io.github.snekse.jdk.dateparser;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OmniDateParserConfigTest {
+
+    @Test
+    void defaults_returnsExpectedDefaultValues() {
+        OmniDateParserConfig config = OmniDateParserConfig.defaults();
+
+        assertEquals(DateOrder.MDY, config.getDateOrder());
+        assertEquals(ZoneOffset.UTC, config.getDefaultZone());
+        assertEquals(70, config.getPivotYear());
+    }
+
+    @Test
+    void builder_canCreateCustomConfiguration() {
+        ZoneId customZone = ZoneId.of("Europe/Paris");
+        OmniDateParserConfig config = OmniDateParserConfig.builder()
+                .dateOrder(DateOrder.DMY)
+                .defaultZone(customZone)
+                .pivotYear(50)
+                .build();
+
+        assertEquals(DateOrder.DMY, config.getDateOrder());
+        assertEquals(customZone, config.getDefaultZone());
+        assertEquals(50, config.getPivotYear());
+    }
+}


### PR DESCRIPTION
🎯 **What:** Addressed the testing gap where `OmniDateParserConfig.defaults()` was entirely untested.

📊 **Coverage:** We now explicitly test that `defaults()` correctly yields a configuration with:
- `DateOrder.MDY`
- `ZoneOffset.UTC` 
- `pivotYear` set to `70`
Additionally, we added a test to ensure the Lombok builder populates a custom configuration as expected.

✨ **Result:** The test coverage for `OmniDateParserConfig` has been significantly improved, ensuring no regressions on these crucial default parsing variables.

---
*PR created automatically by Jules for task [2697018718496137373](https://jules.google.com/task/2697018718496137373) started by @snekse*